### PR TITLE
init.d: fix return value

### DIFF
--- a/assets/etc/init.d/uchiwa
+++ b/assets/etc/init.d/uchiwa
@@ -97,6 +97,7 @@ case "$1" in
       echo "$name is already running"
     else
       start
+      code=$?
     fi
     exit $code
     ;;


### PR DESCRIPTION
If program is dead but pid file exists (ret: 2) or the pidfile does
not exist (ret: 3), the init script return a non-zero value, yet
uchiwa starts fine.
Some configuration management tool  (Puppet here) expects a service
that started normally to return a 0 value. All non-zero value are
considered an error.

This patch aims to update the code return value to the latest possible
value, ie. the one returned by start.
