### PR TITLE
Ensure uchiwa runs with additional sensu group

### DIFF
--- a/assets/etc/init.d/uchiwa
+++ b/assets/etc/init.d/uchiwa
@@ -29,7 +29,7 @@ pidfile="/var/run/$name.pid"
 start() {
 
   # Run the program!
-  chroot --userspec uchiwa:uchiwa / sh -c "
+  chroot --userspec uchiwa:uchiwa --groups sensu / sh -c "
     cd /opt/uchiwa/usr/src/uchiwa
     exec \"$program\" $args
   " > /var/log/$name.log 2> /var/log/$name.err &


### PR DESCRIPTION
`uchiwa` user is created as part of `uchiwa` and `sensu` group, but when using chroot with only `--userspec` it will make it run only as part of the `uchiwa` group. This means no access to the `sensu` accessible `/etc/sensu` directory. As such it will not be able to read the configuration file in `/etc/sensu/uchiwa.js`.
