### PR TITLE
Fallback to su if coreutils isn't new enough

### DIFF
--- a/assets/etc/init.d/uchiwa
+++ b/assets/etc/init.d/uchiwa
@@ -28,7 +28,7 @@ coreutils_required=8
 [ -r /etc/default/$name ] && . /etc/default/$name
 [ -r /etc/sysconfig/$name ] && . /etc/sysconfig/$name
 
-if [ $( echo $coreutils_version'>'$coreutils_required | bc -l) -eq 0 ]; then
+if [ $(echo $coreutils_version'>'$coreutils_required | bc -l) -eq 0 ]; then
   chroot_script="su -s /bin/sh uchiwa"
 else
   chroot_script="chroot --userspec uchiwa:uchiwa --groups sensu /"


### PR DESCRIPTION
Not a terribly clean hack, but this will check to see it chroot is version 8 or higher. If it's not, it will fall back to using su to launch node.

Addresses https://github.com/sensu/uchiwa-build/issues/11
