### PR TITLE
Limit the amount of virtual memory used by uchiwa process

### DIFF
--- a/assets/etc/default/uchiwa
+++ b/assets/etc/default/uchiwa
@@ -1,0 +1,3 @@
+# Limit the amount of virtual memory used in Kb
+# Empty means 'unlimited'
+MAX_VIRTUAL_MEMORY=

--- a/assets/etc/init.d/uchiwa
+++ b/assets/etc/init.d/uchiwa
@@ -29,7 +29,7 @@ pidfile="/var/run/$name.pid"
 start() {
 
   # Run the program!
-  su -s /bin/sh uchiwa -c "cd /opt/uchiwa/src && exec \"$program\" $args" >> /var/log/$name.log 2> /var/log/$name.err &
+  su -s /bin/sh uchiwa -c "ulimit -Sv $MAX_VIRTUAL_MEMORY && cd /opt/uchiwa/src && exec \"$program\" $args" >> /var/log/$name.log 2> /var/log/$name.err &
 
   # Generate the pidfile from here. If we instead made the forked process
   # generate it there will be a race condition between the pidfile writing


### PR DESCRIPTION
I added a new MAX_VIRTUAL_MEMORY variable with an empty default value to avoid any change in the current installations.
This works because if you run "ulimit -Sv" just return the current value, that by default is unlimited.

```
koe@vm01:~# ulimit -Sv && echo $?
unlimited
0
```
