### PR TITLE
running uchiwa as root in order to bind to ports < 1024

### DIFF
--- a/assets/etc/init.d/uchiwa
+++ b/assets/etc/init.d/uchiwa
@@ -29,7 +29,9 @@ pidfile="/var/run/$name.pid"
 start() {
 
   # Run the program!
-  su -s /bin/sh uchiwa -c "cd /opt/uchiwa/src && exec \"$program\" $args" >> /var/log/$name.log 2> /var/log/$name.err &
+  # Running the program as root makes it possible to bind to port 80 or 443 without make extra config-changes to apache or anything else
+  # This is now very useful since uchiwa is capable of doing SSL now
+  -s /bin/sh -c "cd /opt/uchiwa/src && exec \"$program\" $args" >> /var/log/$name.log 2> /var/log/$name.err &
 
   # Generate the pidfile from here. If we instead made the forked process
   # generate it there will be a race condition between the pidfile writing


### PR DESCRIPTION
if we don't run as root we have to go 'the extra mile' in order to bind to port 443 or 80 which are standardised to be used to e.g. ssl connection
if you want to make your dashboard accessible to a wider audience it is clearly useful to use standard ports for this in order for people to be able to use it.
since uchiwa is capable of SSL on it's own, this has gotten way more important than before
