### PR TITLE
Missing flag for cross-compile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -56,7 +56,7 @@ task :build do
     platforms.each do |platform, go_arch|
       puts "Building Uchiwa binary for #{platform} ..."
       output_path = "#{ASSET_DIR}/#{name}-#{go_os}-#{go_arch}"
-      run_command("$GOPATH/bin/godep go build -v -o #{output_path}")
+      run_command("GOOS=#{go_os} GOARCH=#{go_arch} $GOPATH/bin/godep go build -v -o #{output_path}")
     end
   end
 end


### PR DESCRIPTION
The 32 bits binaries produced by the Rakefile were the same because it was missing the cross-compile flags:

Reference: https://github.com/sensu/uchiwa/issues/457
